### PR TITLE
💭 Support `PydanticSQLTableGenerator` used to generate tables

### DIFF
--- a/pydanticORM/generator/__init__.py
+++ b/pydanticORM/generator/__init__.py
@@ -1,0 +1,3 @@
+from pydanticORM.generator._table import PydanticSQLTableGenerator
+
+__all__ = ["PydanticSQLTableGenerator"]

--- a/pydanticORM/generator/_table.py
+++ b/pydanticORM/generator/_table.py
@@ -1,11 +1,11 @@
 """Module providing PydanticSQLTableGenerator."""
 import uuid
-from types import UnionType
+from types import FunctionType
 from typing import Any, get_args, get_origin
 
 from pydantic import BaseModel, ConstrainedStr
 from pydantic.fields import ModelField
-from sqlalchemy import (  # type: ignore
+from sqlalchemy import (
     JSON,
     Column,
     Float,
@@ -16,8 +16,8 @@ from sqlalchemy import (  # type: ignore
     Table,
     UniqueConstraint,
 )
-from sqlalchemy.dialects import postgresql  # type: ignore
-from sqlalchemy.ext.asyncio import AsyncEngine  # type: ignore
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from pydanticORM.handler import TableName_From_Model, TypeConversionError
 from pydanticORM.table import PydanticTableMeta, RelationType
@@ -36,7 +36,7 @@ class PydanticSQLTableGenerator:
         self,
         engine: AsyncEngine,
         metadata: MetaData,
-        schema: dict[str, PydanticTableMeta],
+        schema: dict[str, PydanticTableMeta],  # type: ignore
     ) -> None:
         """Initialize PydanticSQLTableGenerator."""
         self._engine = engine
@@ -61,8 +61,8 @@ class PydanticSQLTableGenerator:
             await conn.run_sync(self._metadata.create_all)
 
     def _get_columns(
-        self, table_data: PydanticTableMeta
-    ) -> tuple[Column[Any] | Column, ...]:
+        self, table_data: PydanticTableMeta  # type: ignore
+    ) -> tuple[Column[Any] | Column, ...]:  # type: ignore
         columns = []
         for field_name, field in table_data.model.__fields__.items():
             kwargs = {
@@ -76,13 +76,13 @@ class PydanticSQLTableGenerator:
                 columns.append(column)
         return tuple(columns)
 
-    def _get_column(
+    def _get_column(  # type: ignore
         self,
-        table_data: PydanticTableMeta,
+        table_data: PydanticTableMeta,  # type: ignore
         field_name: str,
         field: ModelField,
         **kwargs,
-    ) -> Column | None:
+    ) -> Column | None:  # type: ignore
         outer_origin = get_origin(field.outer_type_)
         origin = get_origin(field.type_)
         if outer_origin and outer_origin == list:
@@ -90,7 +90,7 @@ class PydanticSQLTableGenerator:
                 table_data, field_name, field, **kwargs
             )
         if origin:
-            if origin != UnionType:
+            if origin != FunctionType:
                 raise TypeConversionError(field.type_)
             if (
                 column := self._get_column_from_type_args(
@@ -117,30 +117,32 @@ class PydanticSQLTableGenerator:
             return Column(field_name, JSON, **kwargs)
         if field.type_ is list:
             return Column(field_name, JSON, **kwargs)
+        else:
+            raise TypeConversionError(field.type_)
 
-    def _get_column_from_type_args(
+    def _get_column_from_type_args(  # type: ignore
         self,
-        table_data: PydanticTableMeta,
+        table_data: PydanticTableMeta,  # type: ignore
         field_name: str,
         field: ModelField,
         **kwargs,
-    ) -> Column | None:
+    ) -> Column | None:  # type: ignore
         if back_reference := table_data.back_references.get(field_name):
             foreign_table = TableName_From_Model(field.type_, self._schema)
             if (
                 table_data.relationships[field_name].relation_type
                 != RelationType.MANY_TO_MANY
             ):
-                return
+                return  # type: ignore
             if self._m2m.get(f"{table_data.name}.{back_reference}") == field_name:
-                return
+                return  # type: ignore
             self._m2m[f"{foreign_table}.{field_name}"] = back_reference
             Table(
                 table_data.relationships[field_name].m2m_table,
                 self._metadata,
                 *self._get_m2m_columns(table_data.name, foreign_table),
             )
-            return
+            return  # type: ignore
         for arg in get_args(field.type_):
             if arg in [it.model for it in self._schema.values()]:
                 foreign_table = TableName_From_Model(arg, self._schema)

--- a/pydanticORM/generator/_table.py
+++ b/pydanticORM/generator/_table.py
@@ -1,0 +1,171 @@
+"""Module providing PydanticSQLTableGenerator."""
+import uuid
+from types import UnionType
+from typing import Any, get_args, get_origin
+
+from pydantic import BaseModel, ConstrainedStr
+from pydantic.fields import ModelField
+from sqlalchemy import (  # type: ignore
+    JSON,
+    Column,
+    Float,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects import postgresql  # type: ignore
+from sqlalchemy.ext.asyncio import AsyncEngine  # type: ignore
+
+from pydanticORM.handler import TableName_From_Model, TypeConversionError
+from pydanticORM.table import PydanticTableMeta, RelationType
+
+
+class PydanticSQLTableGenerator:
+    """PydanticSQLTableGenerator Class used to generate SQLAlchemy tables, based on the
+    Pydantic models and take:
+
+        `engine`: AsyncEngine
+        `metadata`: MetaData
+        `schema`: `dict[str, PydanticTableMeta]`
+    """
+
+    def __init__(
+        self,
+        engine: AsyncEngine,
+        metadata: MetaData,
+        schema: dict[str, PydanticTableMeta],
+    ) -> None:
+        """Initialize PydanticSQLTableGenerator."""
+        self._engine = engine
+        self._metadata = metadata
+        self._schema = schema
+        self._m2m: dict[str, str] = {}
+
+    async def init(self) -> None:
+        """Generate SQL Alchemy tables."""
+        for tablename, table_data in self._schema.items():
+            unique_constraints = (
+                UniqueConstraint(*cols, name=f"{'_'.join(cols)}_constraint")
+                for cols in table_data.unique_constraints
+            )
+            Table(
+                tablename,
+                self._metadata,
+                *self._get_columns(table_data),
+                *unique_constraints,
+            )
+        async with self._engine.begin() as conn:
+            await conn.run_sync(self._metadata.create_all)
+
+    def _get_columns(
+        self, table_data: PydanticTableMeta
+    ) -> tuple[Column[Any] | Column, ...]:
+        columns = []
+        for field_name, field in table_data.model.__fields__.items():
+            kwargs = {
+                "primary_key": field_name == table_data.pk,
+                "index": field_name in table_data.indexed,
+                "unique": field_name in table_data.unique,
+                "nullable": not field.required,
+            }
+            column = self._get_column(table_data, field_name, field, **kwargs)
+            if column is not None:
+                columns.append(column)
+        return tuple(columns)
+
+    def _get_column(
+        self,
+        table_data: PydanticTableMeta,
+        field_name: str,
+        field: ModelField,
+        **kwargs,
+    ) -> Column | None:
+        outer_origin = get_origin(field.outer_type_)
+        origin = get_origin(field.type_)
+        if outer_origin and outer_origin == list:
+            return self._get_column_from_type_args(
+                table_data, field_name, field, **kwargs
+            )
+        if origin:
+            if origin != UnionType:
+                raise TypeConversionError(field.type_)
+            if (
+                column := self._get_column_from_type_args(
+                    table_data, field_name, field, **kwargs
+                )
+            ) is not None:
+                return column
+            else:
+                raise TypeConversionError(field.type_)
+        if issubclass(field.type_, BaseModel):
+            return Column(field_name, JSON, **kwargs)
+        if field.type_ is uuid.UUID:
+            col_type = (
+                postgresql.UUID if self._engine.name == "postgres" else String(36)
+            )
+            return Column(field_name, col_type, **kwargs)
+        if field.type_ is str or issubclass(field.type_, ConstrainedStr):
+            return Column(field_name, String(field.field_info.max_length), **kwargs)
+        if field.type_ is int:
+            return Column(field_name, Integer, **kwargs)
+        if field.type_ is float:
+            return Column(field_name, Float, **kwargs)
+        if field.type_ is dict:
+            return Column(field_name, JSON, **kwargs)
+        if field.type_ is list:
+            return Column(field_name, JSON, **kwargs)
+
+    def _get_column_from_type_args(
+        self,
+        table_data: PydanticTableMeta,
+        field_name: str,
+        field: ModelField,
+        **kwargs,
+    ) -> Column | None:
+        if back_reference := table_data.back_references.get(field_name):
+            foreign_table = TableName_From_Model(field.type_, self._schema)
+            if (
+                table_data.relationships[field_name].relation_type
+                != RelationType.MANY_TO_MANY
+            ):
+                return
+            if self._m2m.get(f"{table_data.name}.{back_reference}") == field_name:
+                return
+            self._m2m[f"{foreign_table}.{field_name}"] = back_reference
+            Table(
+                table_data.relationships[field_name].m2m_table,
+                self._metadata,
+                *self._get_m2m_columns(table_data.name, foreign_table),
+            )
+            return
+        for arg in get_args(field.type_):
+            if arg in [it.model for it in self._schema.values()]:
+                foreign_table = TableName_From_Model(arg, self._schema)
+                foreign_data = self._schema[foreign_table]
+                return Column(
+                    field_name,
+                    ForeignKey(f"{foreign_table}.{foreign_data.pk}"),
+                    **kwargs,
+                )
+
+    def _get_m2m_columns(self, table_a: str, table_b: str) -> list[Column]:
+        table_a_pk = self._schema[table_a].pk
+        table_b_pk = self._schema[table_b].pk
+        table_a_col_name = table_a
+        table_b_col_name = table_b
+        if table_a == table_b:
+            table_a_col_name = f"{table_a}_a"
+            table_b_col_name = f"{table_b}_b"
+        return [
+            Column(
+                table_a_col_name,
+                ForeignKey(f"{table_a}.{table_a_pk}"),
+            ),
+            Column(
+                table_b_col_name,
+                ForeignKey(f"{table_b}.{table_b_pk}"),
+            ),
+        ]

--- a/pydanticORM/handler/__init__.py
+++ b/pydanticORM/handler/__init__.py
@@ -1,0 +1,18 @@
+from pydanticORM.handler.errors import (
+    ConfigurationError,
+    MismatchingBackReferenceError,
+    MustUnionForeignKeyError,
+    TypeConversionError,
+    UndefinedBackReferenceError,
+)
+from pydanticORM.handler.model import Get_M2M_TableName, TableName_From_Model
+
+__all__ = [
+    "TableName_From_Model",
+    "Get_M2M_TableName",
+    "ConfigurationError",
+    "UndefinedBackReferenceError",
+    "MismatchingBackReferenceError",
+    "MustUnionForeignKeyError",
+    "TypeConversionError",
+]

--- a/pydanticORM/handler/errors.py
+++ b/pydanticORM/handler/errors.py
@@ -1,0 +1,54 @@
+from typing import Type
+
+import sqlalchemy
+
+
+class ConfigurationError(Exception):
+    """Raised for mal-configured database models or schemas."""
+
+    def __init__(self, msg: str):
+        super().__init__(msg)
+
+
+class UndefinedBackReferenceError(ConfigurationError):
+    """Raised when a back reference is missing from a table."""
+
+    def __init__(self, table_a: str, table_b: str, field: str) -> None:
+        super().__init__(
+            f'Many relation defined on "{table_a}.{field}" to table {table_b}" must be'
+            f' defined with a back reference on "{table_a}".'
+        )
+
+
+class MismatchingBackReferenceError(ConfigurationError):
+    """Raised when a back reference is typed incorrectly."""
+
+    def __init__(
+        self, table_a: str, table_b: str, field: str, back_reference: str
+    ) -> None:
+        super().__init__(
+            f'Many relation defined on "{table_a}.{field}" to'
+            f' {table_b}.{back_reference}" must use the same model type back-referenced'
+            f' from table "{table_a}"'
+        )
+
+
+class MustUnionForeignKeyError(ConfigurationError):
+    """Raised when a relation field doesn't allow for just foreign key."""
+
+    def __init__(
+        self, table_a: str, table_b: str, field: str, model_b: Type, pk_type: Type
+    ) -> None:
+        super().__init__(
+            f'Relation defined on "{table_a}.{field}" to "{table_b}" must be a union'
+            f' type of "Model | model_pk_type" e.g. "{model_b.__name__} | {pk_type}"'
+        )
+
+
+class TypeConversionError(ConfigurationError):
+    """Raised when a Python type fails to convert to SQL."""
+
+    def __init__(self, type: Type) -> None:
+        super().__init__(
+            f"Type {type} is not supported by SQLAlchemy {sqlalchemy.__version__}."
+        )

--- a/pydanticORM/handler/errors.py
+++ b/pydanticORM/handler/errors.py
@@ -37,7 +37,7 @@ class MustUnionForeignKeyError(ConfigurationError):
     """Raised when a relation field doesn't allow for just foreign key."""
 
     def __init__(
-        self, table_a: str, table_b: str, field: str, model_b: Type, pk_type: Type
+        self, table_a: str, table_b: str, field: str, model_b: Type, pk_type: Type  # type: ignore
     ) -> None:
         super().__init__(
             f'Relation defined on "{table_a}.{field}" to "{table_b}" must be a union'
@@ -48,7 +48,7 @@ class MustUnionForeignKeyError(ConfigurationError):
 class TypeConversionError(ConfigurationError):
     """Raised when a Python type fails to convert to SQL."""
 
-    def __init__(self, type: Type) -> None:
+    def __init__(self, type: Type) -> None:  # type: ignore
         super().__init__(
             f"Type {type} is not supported by SQLAlchemy {sqlalchemy.__version__}."
         )

--- a/pydanticORM/handler/model.py
+++ b/pydanticORM/handler/model.py
@@ -1,0 +1,16 @@
+"""Utility functions used throughout the project."""
+from typing import Any, Type
+
+from pydanticORM.types import ModelType
+
+
+def TableName_From_Model(model: Type[ModelType], schema: dict[str, Any]) -> str:
+    """Get a tablename from the model and schema."""
+    return [tablename for tablename, data in schema.items() if data.model == model][0]
+
+
+def Get_M2M_TableName(
+    table: str, column: str, other_table: str, other_column: str
+) -> str:
+    """Get the name of a table joining two tables in an ManyToMany relation."""
+    return f"{table}.{column}-to-{other_table}.{other_column}"

--- a/pydanticORM/table.py
+++ b/pydanticORM/table.py
@@ -1,0 +1,39 @@
+"""Module providing classes to store table metadata."""
+from enum import Enum, auto
+from typing import Generic, Type
+
+from pydantic import BaseModel
+from pydantic.generics import GenericModel
+
+from pydanticORM.types import ModelType
+
+
+class RelationType(Enum):
+    """Table relationship types."""
+
+    ONE_TO_MANY = auto()
+    MANY_TO_MANY = auto()
+
+
+class Relation(BaseModel):
+    # https://stackoverflow.com/a/59920780/12927850
+    """Describes a relationship from one table to another."""
+
+    foreign_table: str
+    back_references: str | None = None
+    relation_type: RelationType
+    m2m_table: str | None = None
+
+
+class PydanticTableMeta(GenericModel, Generic[ModelType]):
+    """Class to store table information, including relationships and back references for many-to-many relationships."""
+
+    name: str
+    model: Type[ModelType]
+    pk: str
+    indexed: list[str]
+    unique: list[str]
+    unique_constraints: list[list[str]]
+    columns: list[str]
+    relationships: dict[str, Relation]
+    back_references: dict[str, str]

--- a/pydanticORM/table.py
+++ b/pydanticORM/table.py
@@ -20,9 +20,9 @@ class Relation(BaseModel):
     """Describes a relationship from one table to another."""
 
     foreign_table: str
-    back_references: str | None = None
+    back_references: str | None = None  # type: ignore
     relation_type: RelationType
-    m2m_table: str | None = None
+    m2m_table: str | None = None  # type: ignore
 
 
 class PydanticTableMeta(GenericModel, Generic[ModelType]):

--- a/pydanticORM/types/__init__.py
+++ b/pydanticORM/types/__init__.py
@@ -1,0 +1,5 @@
+"""Provides ModelType TypeVar used throughout lib."""
+
+from pydanticORM.types.base import ModelType
+
+__all__ = ["ModelType"]

--- a/pydanticORM/types/base.py
+++ b/pydanticORM/types/base.py
@@ -1,0 +1,5 @@
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+ModelType = TypeVar("ModelType", bound=BaseModel)


### PR DESCRIPTION
`PydanticSQLTableGenerator` Class used to generate SQLAlchemy tables, based on the Pydantic models and take:
 
- `engine`: AsyncEngine
- `metadata`: MetaData
- `schema`: `dict[str, PydanticTableMeta]`